### PR TITLE
Complete package.json with repository info

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,13 @@
   "license": "MIT",
   "devDependencies": {
     "speedometer": "^1.1.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mafintosh/debugging-stream.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/debugging-stream/issues"
+  },
+  "homepage": "https://github.com/mafintosh/debugging-stream#readme"
 }


### PR DESCRIPTION
Currently npm doesn't link back to this repo, this PR should fix that